### PR TITLE
Extensible html parsing strategies

### DIFF
--- a/src/OpenGraph-Net.Tests/OpenGraph-Net.Tests.csproj
+++ b/src/OpenGraph-Net.Tests/OpenGraph-Net.Tests.csproj
@@ -36,6 +36,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HtmlAgilityPack, Version=1.4.6.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\HtmlAgilityPack.1.4.6\lib\Net40\HtmlAgilityPack.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.1\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/src/OpenGraph-Net.Tests/OpenGraphTests.cs
+++ b/src/OpenGraph-Net.Tests/OpenGraphTests.cs
@@ -2,6 +2,10 @@
 // Copyright SHHH Innovations LLC
 // </copyright>
 
+using System.Collections.Generic;
+using System.Linq;
+using HtmlAgilityPack;
+
 namespace OpenGraph_Net.Tests
 {
     using NUnit.Framework;
@@ -72,6 +76,26 @@ namespace OpenGraph_Net.Tests
 <body>
 </body>
 </html>";
+
+
+        /// <summary>
+        /// Sample content with a link tag for the image
+        /// </summary>
+        private string linkTagForImage = @"<!DOCTYPE HTML>
+<html>
+<head>
+    <meta property=""og:type"" content=""product"" />
+    <meta property=""og:title"" cOntent=""Product Title"" />
+    <meta propErty=""og:uRl"" content=""http://www.test.com"" />
+    <meta property=""og:description"" content=""My Description""/>
+    <meta property=""og:site_Name"" content=""Test Site"">
+    <link rel=""image_src"" href=""http://www.test.com/test.png""/>
+
+</head>
+<body>
+</body>
+</html>";
+
 
         /// <summary>
         /// Tests calling <c>MakeOpenGraph</c> method
@@ -184,7 +208,41 @@ namespace OpenGraph_Net.Tests
             Assert.AreEqual("movie", graph.Type);
             Assert.AreEqual("Amazon.com", graph["site_name"]);
         }
-               
+
+
+        [Test]
+        public void ParseHtml_FindLinkRelImageWithAdditionalStrategy_Test()
+        {
+            OpenGraph.ParsingStrategies.Add(new LinkRelImageParser());
+            OpenGraph graph = OpenGraph.ParseHtml(this.linkTagForImage);
+            Assert.AreEqual("http://www.test.com/test.png", graph.Image.ToString());
+
+        }
+
+        public class LinkRelImageParser : IParsingStrategy
+        {
+            public void Parse(IDictionary<string, string> openGraphData, HtmlDocument document)
+            {
+                string image;
+                openGraphData.TryGetValue("image", out image);
+                if (!string.IsNullOrEmpty(image))
+                    return;
+
+
+                var linkTags = document.DocumentNode.SelectNodes("//link");
+
+                var linkTag = (from link in linkTags ?? new HtmlNodeCollection(null)
+                    where link.Attributes.Contains("rel") && link.Attributes["rel"].Value == "image_src"
+                    select link).FirstOrDefault();
+
+                if (linkTag != null && linkTag.Attributes.Contains("href"))
+                    image = linkTag.Attributes["href"].Value;
+
+                openGraphData["image"] = image;
+
+
+            }
+        }
         
     }
 }

--- a/src/OpenGraph-Net.Tests/OpenGraphTests.cs
+++ b/src/OpenGraph-Net.Tests/OpenGraphTests.cs
@@ -180,9 +180,11 @@ namespace OpenGraph_Net.Tests
             Assert.AreEqual("http://www.amazon.com/dp/B0019MFY3Q/ref=tsm_1_fb_lk", graph.Url.ToString());
             Assert.AreEqual("Spaced: The Complete Series", graph.Title);
             Assert.IsTrue(graph["description"].Contains("Spaced"));
-            Assert.AreEqual("http://ecx.images-amazon.com/images/I/51sWMo4CBcL._SL160_.jpg", graph.Image.ToString());
+            Assert.AreEqual("http://ecx.images-amazon.com/images/I/51sWMo4CBcL._SS500_.jpg", graph.Image.ToString());
             Assert.AreEqual("movie", graph.Type);
             Assert.AreEqual("Amazon.com", graph["site_name"]);
         }
+               
+        
     }
 }

--- a/src/OpenGraph-Net/IParsingStrategy.cs
+++ b/src/OpenGraph-Net/IParsingStrategy.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using HtmlAgilityPack;
+
+namespace OpenGraph_Net
+{
+    public interface IParsingStrategy
+    {
+        void Parse(IDictionary<string, string> result, HtmlDocument document);
+    }
+}

--- a/src/OpenGraph-Net/IParsingStrategy.cs
+++ b/src/OpenGraph-Net/IParsingStrategy.cs
@@ -5,6 +5,6 @@ namespace OpenGraph_Net
 {
     public interface IParsingStrategy
     {
-        void Parse(IDictionary<string, string> result, HtmlDocument document);
+        void Parse(IDictionary<string, string> openGraphData, HtmlDocument document);
     }
 }

--- a/src/OpenGraph-Net/OpenGraph-Net.csproj
+++ b/src/OpenGraph-Net/OpenGraph-Net.csproj
@@ -58,6 +58,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="InvalidSpecificationException.cs" />
+    <Compile Include="IParsingStrategy.cs" />
+    <Compile Include="OpenGraphMetaTagParser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="OpenGraph.cs" />
     <Compile Include="ReadOnlyDictionaryException.cs" />

--- a/src/OpenGraph-Net/OpenGraphMetaTagParser.cs
+++ b/src/OpenGraph-Net/OpenGraphMetaTagParser.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using HtmlAgilityPack;
+
+namespace OpenGraph_Net
+{
+    public class OpenGraphMetaTagParser : IParsingStrategy
+    {
+        public void Parse(IDictionary<string, string> openGraphData, HtmlDocument document)
+        {
+            HtmlNodeCollection allMeta = document.DocumentNode.SelectNodes("//meta");
+
+            var openGraphMetaTags = from meta in allMeta ?? new HtmlNodeCollection(null)
+                where (meta.Attributes.Contains("property") && meta.Attributes["property"].Value.StartsWith("og:")) ||
+                      (meta.Attributes.Contains("name") && meta.Attributes["name"].Value.StartsWith("og:"))
+                select meta;
+
+            foreach (HtmlNode metaTag in openGraphMetaTags)
+            {
+                string value = GetOpenGraphValue(metaTag);
+                string property = GetOpenGraphKey(metaTag);
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                if (openGraphData.ContainsKey(property))
+                {
+                    continue;
+                }
+
+                openGraphData.Add(property, value);
+            }
+
+        }
+
+
+        /// <summary>
+        /// Gets the open graph key.
+        /// </summary>
+        /// <param name="metaTag">The meta tag.</param>
+        /// <returns>Returns the key stored from the meta tag</returns>
+        private static string GetOpenGraphKey(HtmlNode metaTag)
+        {
+            if (metaTag.Attributes.Contains("property"))
+            {
+                return CleanOpenGraphKey(metaTag.Attributes["property"].Value);
+            }
+            else
+            {
+                return CleanOpenGraphKey(metaTag.Attributes["name"].Value);
+            }
+        }
+
+
+        /// <summary>
+        /// Cleans the open graph key.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>strips the <c>og:</c> namespace from the value</returns>
+        private static string CleanOpenGraphKey(string value)
+        {
+            return value.Replace("og:", string.Empty).ToLower(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Gets the open graph value.
+        /// </summary>
+        /// <param name="metaTag">The meta tag.</param>
+        /// <returns>Returns the value from the meta tag</returns>
+        private static string GetOpenGraphValue(HtmlNode metaTag)
+        {
+            if (!metaTag.Attributes.Contains("content"))
+            {
+                return string.Empty;
+            }
+
+            return metaTag.Attributes["content"].Value;
+        }
+    }
+}


### PR DESCRIPTION
Hey there

I don't know if this is of any interest to pull in.
I needed to pull out metadata from documents where they aren't always compliant to OpenGraph. This is a great start though so I decided to use it but add some fallback parsing strategies.

I'm happy to use it from my fork, but if you'd like to pull it across I'm also happy to tweak the implementation.