### PR TITLE
Add support for passing an HttpClient into ParseUrlAsync()

### DIFF
--- a/src/OpenGraphNet/HttpDownloader.cs
+++ b/src/OpenGraphNet/HttpDownloader.cs
@@ -39,7 +39,7 @@ public class HttpDownloader
     {
         // Configure the shared client with opinionated defaults.
 #if NET6_OR_GREATER
-        SharedHttpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+        SharedHttpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
         SharedHttpClient.DefaultRequestVersion = HttpVersion.Version20;
 #endif
     }

--- a/src/OpenGraphNet/OpenGraph.cs
+++ b/src/OpenGraphNet/OpenGraph.cs
@@ -210,9 +210,10 @@ public class OpenGraph
     /// <param name="userAgent">The user agent.</param>
     /// <param name="validateSpecification">if set to <c>true</c> validate minimum Open Graph specification.</param>
     /// <param name="timeout">The timeout in milliseconds.</param>
+    /// <param name="httpClient">An optional <see cref="HttpClient"/> to use to download the page for parsing.</param>
     /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns><see cref="Task{OpenGraph}" />.</returns>
-    public static Task<OpenGraph> ParseUrlAsync(string url, string? userAgent = null, bool validateSpecification = false, int timeout = 90000, CancellationToken cancellationToken = default)
+    public static Task<OpenGraph> ParseUrlAsync(string url, string? userAgent = null, bool validateSpecification = false, int timeout = 90000, HttpClient? httpClient = null, CancellationToken cancellationToken = default)
     {
         if (!Regex.IsMatch(url, "^https?://", RegexOptions.IgnoreCase))
         {
@@ -222,7 +223,7 @@ public class OpenGraph
         userAgent ??= $"OpenGraphNet/{Utilities.GetVersionString()}";
 
         Uri uri = new(url);
-        return ParseUrlAsync(uri, userAgent, validateSpecification, timeout, cancellationToken);
+        return ParseUrlAsync(uri, userAgent, validateSpecification, timeout, httpClient, cancellationToken);
     }
 
     /// <summary>
@@ -232,13 +233,14 @@ public class OpenGraph
     /// <param name="userAgent">The user agent.</param>
     /// <param name="validateSpecification">if set to <c>true</c> [validate specification].</param>
     /// <param name="timeout">The timeout in milliseconds.</param>
+    /// <param name="httpClient">An optional <see cref="HttpClient"/> to use to download the page for parsing.</param>
     /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns><see cref="Task{OpenGraph}" />.</returns>
-    public static async Task<OpenGraph> ParseUrlAsync(Uri url, string userAgent = "", bool validateSpecification = false, int timeout = 90000, CancellationToken cancellationToken = default)
+    public static async Task<OpenGraph> ParseUrlAsync(Uri url, string userAgent = "", bool validateSpecification = false, int timeout = 90000, HttpClient? httpClient = null, CancellationToken cancellationToken = default)
     {
         OpenGraph result = new() { OriginalUrl = url };
 
-        HttpDownloader downloader = new(url, null, userAgent, timeout);
+        HttpDownloader downloader = new(url, null, userAgent, timeout, httpClient);
         string html = await downloader.GetPageAsync(cancellationToken).ConfigureAwait(false);
         result.OriginalHtml = html;
 

--- a/src/OpenGraphNet/OpenGraph.cs
+++ b/src/OpenGraphNet/OpenGraph.cs
@@ -210,6 +210,20 @@ public class OpenGraph
     /// <param name="userAgent">The user agent.</param>
     /// <param name="validateSpecification">if set to <c>true</c> validate minimum Open Graph specification.</param>
     /// <param name="timeout">The timeout in milliseconds.</param>
+    /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns><see cref="Task{OpenGraph}" />.</returns>
+    public static Task<OpenGraph> ParseUrlAsync(string url, string? userAgent = null, bool validateSpecification = false, int timeout = 90000, CancellationToken cancellationToken = default)
+    {
+        return ParseUrlAsync(url, userAgent, validateSpecification, timeout, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Parses the URL asynchronously.
+    /// </summary>
+    /// <param name="url">The URL.</param>
+    /// <param name="userAgent">The user agent.</param>
+    /// <param name="validateSpecification">if set to <c>true</c> validate minimum Open Graph specification.</param>
+    /// <param name="timeout">The timeout in milliseconds.</param>
     /// <param name="httpClient">An optional <see cref="HttpClient"/> to use to download the page for parsing.</param>
     /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns><see cref="Task{OpenGraph}" />.</returns>
@@ -224,6 +238,20 @@ public class OpenGraph
 
         Uri uri = new(url);
         return ParseUrlAsync(uri, userAgent, validateSpecification, timeout, httpClient, cancellationToken);
+    }
+
+    /// <summary>
+    /// Parses the URL asynchronously.
+    /// </summary>
+    /// <param name="url">The URL.</param>
+    /// <param name="userAgent">The user agent.</param>
+    /// <param name="validateSpecification">if set to <c>true</c> [validate specification].</param>
+    /// <param name="timeout">The timeout in milliseconds.</param>
+    /// <param name="cancellationToken">The cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns><see cref="Task{OpenGraph}" />.</returns>
+    public static async Task<OpenGraph> ParseUrlAsync(Uri url, string userAgent = "", bool validateSpecification = false, int timeout = 90000, CancellationToken cancellationToken = default)
+    {
+        return await ParseUrlAsync(url, userAgent, validateSpecification, timeout, null, cancellationToken);
     }
 
     /// <summary>

--- a/tests/OpenGraphNet.Tests/OpenGraphTests.cs
+++ b/tests/OpenGraphNet.Tests/OpenGraphTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace OpenGraphNet.Tests;
 
+using System.Net;
+
 /// <summary>
 /// The open graph test fixture.
 /// </summary>
@@ -509,6 +511,28 @@ public class OpenGraphTests
             referrer: "http://www.mysite.com",
             userAgent: "test",
             timeout: 100000);
+        string html = await downloader.GetPageAsync().ConfigureAwait(false);
+
+        Assert.NotEqual(string.Empty, html);
+    }
+
+    /// <summary>
+    /// Defines the test method TestDownloader. Issue #38.
+    /// </summary>
+    /// <returns>A/an <c>Task</c>.</returns>
+    [Fact]
+    public async Task TestDownloaderWithHttpClient()
+    {
+        HttpClientHandler compressionHandler = new() { AutomaticDecompression = DecompressionMethods.All };
+        var httpClient = new HttpClient(compressionHandler, disposeHandler: true);
+        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("OpenGraphNet-test/1.0");
+
+        var downloader = new HttpDownloader(
+            new Uri("https://marketplace.visualstudio.com/items?itemName=sdras.vue-vscode-extensionpack"),
+            referrer: "http://www.mysite.com",
+            userAgent: "test",
+            timeout: 100000,
+            httpClient: httpClient);
         string html = await downloader.GetPageAsync().ConfigureAwait(false);
 
         Assert.NotEqual(string.Empty, html);


### PR DESCRIPTION
Resolves #39

1. Add an optional parameter, HttpClient? httpClient to ParseUrlAsync()
2. Add test case, TestDownloaderWithHttpClient()

One thing of note - if you don't pass an HttpClient this still creates an individual client for every instance of HttpDownloader. This does go a little against the HttpClient best practice documentation, where you'd have a single long lived static instance of HttpClient, but to do that I'd have to break your API and that's just mean :)

There are some unit tests that fail, but they were failing before I started, so I haven't made anything wose.